### PR TITLE
Feature/ignore validation response

### DIFF
--- a/src/Indice.Psd2.Cryptography/Tokens/HttpMessageSigning/HttpSignatureDelegatingHandler.cs
+++ b/src/Indice.Psd2.Cryptography/Tokens/HttpMessageSigning/HttpSignatureDelegatingHandler.cs
@@ -16,6 +16,10 @@ namespace Indice.Psd2.Cryptography.Tokens.HttpMessageSigning
     public class HttpSignatureDelegatingHandler : DelegatingHandler
     {
         /// <summary>
+        /// Defines if the response will be validated
+        /// </summary>
+        private bool _validateResponse = true;
+        /// <summary>
         /// The header name where the certificate used for signing the request will reside, in base64 encoding.  This header will be present in the request object if a signature is contained.
         /// </summary>
         public static string RequestSignatureCertificateHeaderName = "TTP-Signature-Certificate";
@@ -66,7 +70,7 @@ namespace Indice.Psd2.Cryptography.Tokens.HttpMessageSigning
         /// </summary>
         public string[] HeaderNames { get; }
         /// <summary>
-        /// Paths that are exluded, optionally based on provided HTTP method.
+        /// Paths that are excluded, optionally based on provided HTTP method.
         /// </summary>
         public IDictionary<string, string> IgnoredPaths { get; } = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
 
@@ -101,6 +105,13 @@ namespace Indice.Psd2.Cryptography.Tokens.HttpMessageSigning
         }
 
         /// <summary>
+        /// Ignores the Response Validation 
+        /// </summary>
+        public void IgnoreResponseValidation() {
+            _validateResponse = false;
+        }
+
+        /// <summary>
         /// Sends an HTTP request to the inner handler to send to the server as an asynchronous operation.
         /// </summary>
         /// <param name="request">The HTTP request message to send to the server.</param>
@@ -109,7 +120,9 @@ namespace Indice.Psd2.Cryptography.Tokens.HttpMessageSigning
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
             await SignRequest(request);
             var response = await base.SendAsync(request, cancellationToken);
-            await ValidateResponse(request, response);
+            if (_validateResponse) {
+                await ValidateResponse(request, response);
+            }
             return response;
         }
 

--- a/src/Indice.Psd2.Cryptography/Tokens/HttpMessageSigning/HttpSignatureDelegatingHandler.cs
+++ b/src/Indice.Psd2.Cryptography/Tokens/HttpMessageSigning/HttpSignatureDelegatingHandler.cs
@@ -16,9 +16,9 @@ namespace Indice.Psd2.Cryptography.Tokens.HttpMessageSigning
     public class HttpSignatureDelegatingHandler : DelegatingHandler
     {
         /// <summary>
-        /// Defines if the response will be validated
+        /// Defines if the response will be validated or not
         /// </summary>
-        private bool _validateResponse = true;
+        private bool _ignoreResponseValidation = false;
         /// <summary>
         /// The header name where the certificate used for signing the request will reside, in base64 encoding.  This header will be present in the request object if a signature is contained.
         /// </summary>
@@ -108,7 +108,7 @@ namespace Indice.Psd2.Cryptography.Tokens.HttpMessageSigning
         /// Ignores the Response Validation 
         /// </summary>
         public void IgnoreResponseValidation() {
-            _validateResponse = false;
+            _ignoreResponseValidation = true;
         }
 
         /// <summary>
@@ -120,13 +120,14 @@ namespace Indice.Psd2.Cryptography.Tokens.HttpMessageSigning
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
             await SignRequest(request);
             var response = await base.SendAsync(request, cancellationToken);
-            if (_validateResponse) {
-                await ValidateResponse(request, response);
-            }
+            await ValidateResponse(request, response);
             return response;
         }
 
         private async Task ValidateResponse(HttpRequestMessage request, HttpResponseMessage response) {
+            if (_ignoreResponseValidation) {
+                return;
+            }
             if (StringExtensions.IsIgnoredPath(IgnoredPaths, request.RequestUri.AbsolutePath, request.Method.Method)) {
                 return;
             }

--- a/src/Indice.Psd2.Cryptography/Tokens/HttpMessageSigning/HttpSignatureDelegatingHandler.cs
+++ b/src/Indice.Psd2.Cryptography/Tokens/HttpMessageSigning/HttpSignatureDelegatingHandler.cs
@@ -16,9 +16,9 @@ namespace Indice.Psd2.Cryptography.Tokens.HttpMessageSigning
     public class HttpSignatureDelegatingHandler : DelegatingHandler
     {
         /// <summary>
-        /// Defines if the response will be validated or not
+        /// Ignores the Response Validation 
         /// </summary>
-        private bool _ignoreResponseValidation = false;
+        public bool IgnoreResponseValidation { get; set; } 
         /// <summary>
         /// The header name where the certificate used for signing the request will reside, in base64 encoding.  This header will be present in the request object if a signature is contained.
         /// </summary>
@@ -105,13 +105,6 @@ namespace Indice.Psd2.Cryptography.Tokens.HttpMessageSigning
         }
 
         /// <summary>
-        /// Ignores the Response Validation 
-        /// </summary>
-        public void IgnoreResponseValidation() {
-            _ignoreResponseValidation = true;
-        }
-
-        /// <summary>
         /// Sends an HTTP request to the inner handler to send to the server as an asynchronous operation.
         /// </summary>
         /// <param name="request">The HTTP request message to send to the server.</param>
@@ -125,7 +118,7 @@ namespace Indice.Psd2.Cryptography.Tokens.HttpMessageSigning
         }
 
         private async Task ValidateResponse(HttpRequestMessage request, HttpResponseMessage response) {
-            if (_ignoreResponseValidation) {
+            if (IgnoreResponseValidation) {
                 return;
             }
             if (StringExtensions.IsIgnoredPath(IgnoredPaths, request.RequestUri.AbsolutePath, request.Method.Method)) {


### PR DESCRIPTION
# What ?
I've added a new private property `_ignoreResponseValidation` and a public method `IgnoreResponseValidation` so a  TPP that configures the `HttpSignatureDelegatingHandler` will be able to ignore the `ResponseValidation` .

# Why ?
As a TPP that will use this package to configure and sign the Request Headers, we want to ignore the `ResponsValidation` feature because some of the PSD2 APIs that we are consuming (eg Winbank, Eurobank) require request signing only. For this reason, the `HttpSignatureDelegatingHandler` is throwing an Exception.

## Exception thrown
```
Missing certificate in HTTP header 'ASPSP-Signature-Certificate'. Cannot validate signature.
```

## But Why did you not use "IgnorePath" feature ?
Because this feature is ignoring both the request and the response signing. We need to ignore only the latter.

# Testing ?
- I have created a unit test that uses this new feature
- I have added the `.csproj` in a solution locally, and 
  - Used a TPP with this feature on (ignore response signing)
  - Used a TPP with this feature off (use response signing)

# Anything Else ?
That's all