### PR TITLE
Set RequestSignatureCertificateHeaderName name in HttpSignatureDelegatingHandler

### DIFF
--- a/src/Indice.Psd2.Cryptography/Tokens/HttpMessageSigning/HttpSignatureDelegatingHandler.cs
+++ b/src/Indice.Psd2.Cryptography/Tokens/HttpMessageSigning/HttpSignatureDelegatingHandler.cs
@@ -101,6 +101,14 @@ namespace Indice.Psd2.Cryptography.Tokens.HttpMessageSigning
         }
 
         /// <summary>
+        /// Change the default name of the <see cref="RequestSignatureCertificateHeaderName"/> and use a specific one
+        /// </summary>
+        /// <param name="name">The new name that will be used in signature certificate header</param>
+        public void SetRequestSignatureCertificateHeaderName(string name) {
+            RequestSignatureCertificateHeaderName = name;
+        }
+
+        /// <summary>
         /// Sends an HTTP request to the inner handler to send to the server as an asynchronous operation.
         /// </summary>
         /// <param name="request">The HTTP request message to send to the server.</param>

--- a/src/Indice.Psd2.Cryptography/Tokens/HttpMessageSigning/HttpSignatureDelegatingHandler.cs
+++ b/src/Indice.Psd2.Cryptography/Tokens/HttpMessageSigning/HttpSignatureDelegatingHandler.cs
@@ -18,7 +18,7 @@ namespace Indice.Psd2.Cryptography.Tokens.HttpMessageSigning
         /// <summary>
         /// The header name where the certificate used for signing the request will reside, in base64 encoding.  This header will be present in the request object if a signature is contained.
         /// </summary>
-        public static string RequestSignatureCertificateHeaderName = "TTP-Signature-Certificate";
+        public string RequestSignatureCertificateHeaderName { get; set; } = "TTP-Signature-Certificate";
         /// <summary>
         /// The header name where the certificate used for validating the response will reside, in base64 encoding.  This header will be present in the request object if a signature is contained.
         /// </summary>
@@ -98,14 +98,6 @@ namespace Indice.Psd2.Cryptography.Tokens.HttpMessageSigning
             var httpMethod = string.Join('|', httpMethods);
             IgnoredPaths.Add(path, httpMethod);
             return;
-        }
-
-        /// <summary>
-        /// Change the default name of the <see cref="RequestSignatureCertificateHeaderName"/> and use a specific one
-        /// </summary>
-        /// <param name="name">The new name that will be used in signature certificate header</param>
-        public void SetRequestSignatureCertificateHeaderName(string name) {
-            RequestSignatureCertificateHeaderName = name;
         }
 
         /// <summary>


### PR DESCRIPTION
# What ?
I've added a new public method `SetRequestSignatureCertificateHeaderName` so a TPP can alter the default name of the header `TTP-Signature-Certificate`.

# Why ?
Some PSD2 API's (eg [PiraeusBank](https://rapidlink.piraeusbank.gr/node/1938)) require the name of the header in their own way, eg `X-Client-Certificate` instead of `TTP-Signature-Certificate`. 

# Testing ?
I've setup the `.csproj` in a local API and I have successfully altered and sent the header name with the new value that has been setup in the `DI Config`  section.

# Anything Else ?
The solution provided is only for one header. If in the future, we'd like to change more header names, we must provide a more generic solution.