### PR TITLE
Add logic for IHttpClientValidationKeysStore when verifying the http request

### DIFF
--- a/src/Indice.Oba.AspNetCore/Middleware/DefaultHttpClientValidationKeysStore.cs
+++ b/src/Indice.Oba.AspNetCore/Middleware/DefaultHttpClientValidationKeysStore.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Indice.Oba.AspNetCore.Middleware;
+
+/// <summary>
+/// The default http client validation keys store.
+/// </summary>
+public class DefaultHttpClientValidationKeysStore : IHttpClientValidationKeysStore
+{
+    /// <inheritdoc/>
+    public Task<IEnumerable<SecurityKey>> GetValidationKeysAsync() =>
+        Task.FromResult(Enumerable.Empty<SecurityKey>());
+}

--- a/src/Indice.Oba.AspNetCore/Middleware/HttpSignatureConfiguration.cs
+++ b/src/Indice.Oba.AspNetCore/Middleware/HttpSignatureConfiguration.cs
@@ -28,6 +28,7 @@ public static class HttpSignatureConfiguration
             services.AddSingleton(options);
             builder.Options = options;
         }
+        builder.Services.AddSingleton<IHttpClientValidationKeysStore, DefaultHttpClientValidationKeysStore>();
         return builder;
     }
 

--- a/src/Indice.Oba.AspNetCore/Middleware/IHttpClientValidationKeysStore.cs
+++ b/src/Indice.Oba.AspNetCore/Middleware/IHttpClientValidationKeysStore.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Indice.Oba.AspNetCore.Middleware;
+
+/// <summary>
+/// Interface for the validation key store of the client.
+/// </summary>
+public interface IHttpClientValidationKeysStore
+{
+    /// <summary>
+    /// Gets all validation keys.
+    /// </summary>
+    /// <returns></returns>
+    Task<IEnumerable<SecurityKey>> GetValidationKeysAsync();
+}

--- a/src/Indice.Psd2.Cryptography/Tokens/HttpMessageSigning/HttpSignature.cs
+++ b/src/Indice.Psd2.Cryptography/Tokens/HttpMessageSigning/HttpSignature.cs
@@ -30,6 +30,12 @@ public class HttpSignature : Dictionary<string, object>
         [SecurityAlgorithms.RsaSha256] = "rsa-sha256",
         [SecurityAlgorithms.RsaSha384] = "rsa-sha384",
         [SecurityAlgorithms.RsaSha512] = "rsa-sha512",
+        [SecurityAlgorithms.HmacSha256Signature] = "hmac-sha256",
+        [SecurityAlgorithms.HmacSha256] = "hmac-sha256",
+        [SecurityAlgorithms.HmacSha384Signature] = "hmac-sha384",
+        [SecurityAlgorithms.HmacSha384] = "hmac-sha384",
+        [SecurityAlgorithms.HmacSha512Signature] = "hmac-sha512",
+        [SecurityAlgorithms.HmacSha512] = "hmac-sha512"
     };
 
     /// <summary>
@@ -38,7 +44,10 @@ public class HttpSignature : Dictionary<string, object>
     private readonly IDictionary<string, string> InboundAlgorithmMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
         ["rsa-sha256"] = SecurityAlgorithms.RsaSha256Signature,
         ["rsa-sha384"] = SecurityAlgorithms.RsaSha384Signature,
-        ["rsa-sha512"] = SecurityAlgorithms.RsaSha512Signature
+        ["rsa-sha512"] = SecurityAlgorithms.RsaSha512Signature,
+        ["hmac-sha256"] = SecurityAlgorithms.HmacSha256Signature,
+        ["hmac-sha384"] = SecurityAlgorithms.HmacSha384Signature,
+        ["hmac-sha512"] = SecurityAlgorithms.HmacSha512Signature
     };
 
     /// <summary>
@@ -364,6 +373,6 @@ public class HttpSignature : Dictionary<string, object>
         }
     }
 
-    private static string GenerateMessage(IEnumerable<KeyValuePair<string, string>> headerKeyValues) => 
+    private static string GenerateMessage(IEnumerable<KeyValuePair<string, string>> headerKeyValues) =>
         string.Join("\n", headerKeyValues.Where(x => x.Value != null).Select(x => $"{x.Key.ToLowerInvariant()}: {SerializeComponent(x.Value)}"));
 }


### PR DESCRIPTION
## Added
- Hmac 256, 384, 512 algorithms for http signatures
- new interface to retriece client secrets when verifying the http request

## Changed
- `HttpMiddleware` logic, to verify all incoming requests with either a public key from the header of from the client secret store
- `Debug.WriteLine` with `logger.Debug` in http middleware