### PR TITLE
Full Support of hmac, avoid exceptions when algorithm is not supported

### DIFF
--- a/samples/Indice.Cryptography.Host/Swagger/OpenApiExtensions.cs
+++ b/samples/Indice.Cryptography.Host/Swagger/OpenApiExtensions.cs
@@ -67,7 +67,7 @@ public static class OpenApiExtensions
             array = new OpenApiArray();
             array.AddRange(((IEnumerable)instance).Cast<object>().Select(x => GetStructValue(itemType ?? x.GetType(), x) ?? ToOpenApiAny(itemType ?? x.GetType(), x)));
         }
-        return array;
+        return array!;
     }
 
     private static IOpenApiPrimitive GetStructValue(Type type, object value) {
@@ -104,18 +104,18 @@ public static class OpenApiExtensions
             type.IsEnum || Nullable.GetUnderlyingType(type)?.IsEnum == true) {
 #endif
             openValue = new OpenApiString($"{value}");
-        } else if (type.IsValueType && !type.IsPrimitive && !type.Namespace.StartsWith("System") && !type.IsEnum) {
+        } else if (type.IsValueType && !type.IsPrimitive && !type.Namespace!.StartsWith("System") && !type.IsEnum) {
             openValue = new OpenApiString($"{value}");
         }
 
-        return openValue;
+        return openValue!;
     }
 
     private static Type GetAnyElementType(Type type) {
         // Type is Array
         // short-circuit if you expect lots of arrays 
         if (type.IsArray)
-            return type.GetElementType();
+            return type.GetElementType()!;
 
         // type is IEnumerable<T>;
         if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
@@ -126,6 +126,6 @@ public static class OpenApiExtensions
                                 .Where(t => t.IsGenericType &&
                                        t.GetGenericTypeDefinition() == typeof(IEnumerable<>))
                                 .Select(t => t.GenericTypeArguments[0]).FirstOrDefault();
-        return enumType;
+        return enumType!;
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup Label="Assembly Common">
       <Copyright>Copyright (c) 2019 Indice</Copyright>
       <TargetFramework>net8.0</TargetFramework>
-      <VersionPrefix>8.0.0</VersionPrefix>
+      <VersionPrefix>8.0.1</VersionPrefix>
       <!--<VersionSuffix>beta-01</VersionSuffix>-->
       <Authors>Constantinos Leftheris, Giannis Tsenes</Authors>
       <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup Label="Assembly Common">
       <Copyright>Copyright (c) 2019 Indice</Copyright>
       <TargetFramework>net8.0</TargetFramework>
-      <VersionPrefix>8.0.1</VersionPrefix>
+      <VersionPrefix>8.1.0</VersionPrefix>
       <!--<VersionSuffix>beta-01</VersionSuffix>-->
       <Authors>Constantinos Leftheris, Giannis Tsenes</Authors>
       <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Indice.Cryptography.AspNetCore/Features/CertificateConfigurationExtensions.cs
+++ b/src/Indice.Cryptography.AspNetCore/Features/CertificateConfigurationExtensions.cs
@@ -18,7 +18,7 @@ public static class CertificateConfigurationExtensions
     /// <param name="hostEnvironment">The hosting environment</param>
     /// <param name="configureAction">Delegate for configuring options for certificate endpoints feature.</param>
     /// <returns></returns>
-    public static IServiceCollection AddCertificateServer(this IServiceCollection services, IWebHostEnvironment hostEnvironment, Action<CertificateEndpointsOptions> configureAction = null!) {
+    public static IServiceCollection AddCertificateServer(this IServiceCollection services, IWebHostEnvironment hostEnvironment, Action<CertificateEndpointsOptions>? configureAction = null) {
         AddCertificateServerInternal(services, hostEnvironment, configureAction);
         services.AddEndpointsApiExplorer();
         return services;
@@ -31,7 +31,7 @@ public static class CertificateConfigurationExtensions
     /// <param name="hostEnvironment">The hosting environment</param>
     /// <param name="configureAction">Delegate for configuring options for certificate endpoints feature.</param>
     /// <returns></returns>
-    internal static IServiceCollection AddCertificateServerInternal(this IServiceCollection services, IWebHostEnvironment hostEnvironment, Action<CertificateEndpointsOptions> configureAction = null!) {
+    internal static IServiceCollection AddCertificateServerInternal(this IServiceCollection services, IWebHostEnvironment hostEnvironment, Action<CertificateEndpointsOptions>? configureAction = null) {
         var options = new CertificateEndpointsOptions {
             IssuerDomain = "www.example.com",
             PfxPassphrase = "???"

--- a/src/Indice.Cryptography.AspNetCore/Features/CertificateEndpointsOptions.cs
+++ b/src/Indice.Cryptography.AspNetCore/Features/CertificateEndpointsOptions.cs
@@ -8,15 +8,15 @@ public class CertificateEndpointsOptions
     /// <summary>
     /// Path to where CA certificate should be stored/retrieved.
     /// </summary>
-    public string Path { get; set; }
+    public string? Path { get; set; }
     /// <summary>
     /// The domain name where this application is hosted. Ex https://example.com
     /// </summary>
-    public string IssuerDomain { get; set; }
+    public string IssuerDomain { get; set; } = null!;
     /// <summary>
     /// The PFX passphrase for the issuer certs.
     /// </summary>
-    public string PfxPassphrase { get; set; }
+    public string PfxPassphrase { get; set; } = null!;
 
-    internal IServiceCollection Services;
+    internal IServiceCollection Services = null!;
 }

--- a/src/Indice.Cryptography.AspNetCore/Features/CertificateHandlers.cs
+++ b/src/Indice.Cryptography.AspNetCore/Features/CertificateHandlers.cs
@@ -13,7 +13,7 @@ namespace Indice.Cryptography.AspNetCore.Features;
 internal static class CertificateHandlers
 {
     public static FileStreamHttpResult GetIssuerCertificate(CertificateEndpointsOptions options) {
-        var file = new FileInfo(Path.Combine(options.Path, "ca.cer"));
+        var file = new FileInfo(Path.Combine(options.Path!, "ca.cer"));
         return TypedResults.File(file.OpenRead(), contentType: "application/x-x509-ca-cert", fileDownloadName: "ca.cer", lastModified: file.LastWriteTimeUtc);
     }
 
@@ -21,7 +21,7 @@ internal static class CertificateHandlers
             ICertificatesStore store, 
             CertificateEndpointsOptions options, 
             Psd2CertificateRequest request) {
-        var issuer = new X509Certificate2(Path.Combine(options.Path, "ca.pfx"), options.PfxPassphrase, X509KeyStorageFlags.MachineKeySet);
+        var issuer = new X509Certificate2(Path.Combine(options.Path!, "ca.pfx"), options.PfxPassphrase, X509KeyStorageFlags.MachineKeySet);
         var manager = new CertificateManager();
         var cert = manager.CreateQualifiedCertificate(request, options.IssuerDomain, issuer, out _);
         var response = await store.Add(cert, request);
@@ -39,7 +39,7 @@ internal static class CertificateHandlers
         }
         if (format.ToLower() == "pfx" && string.IsNullOrEmpty(password)) {
             var errors = new Dictionary<string, string[]> {
-                [nameof(password)] = new[] { "A password is required in order to export to pfx" } 
+                [nameof(password)] = ["A password is required in order to export to pfx"]
             };
             return TypedResults.ValidationProblem(errors);
         }
@@ -63,10 +63,10 @@ internal static class CertificateHandlers
     public static async Task<FileContentHttpResult> RevocationList(
             ICertificatesStore store,
             CertificateEndpointsOptions options) {
-        var issuer = new X509Certificate2(Path.Combine(options.Path, "ca.pfx"), options.PfxPassphrase);
+        var issuer = new X509Certificate2(Path.Combine(options.Path!, "ca.pfx"), options.PfxPassphrase);
         var results = await store.GetRevocationList();
         var crl = new CertificateRevocationList {
-            AuthorizationKeyId = issuer.GetSubjectKeyIdentifier().ToLower(),
+            AuthorizationKeyId = issuer.GetSubjectKeyIdentifier()?.ToLower(),
             Country = "GR",
             Organization = "Sample Authority",
             IssuerCommonName = "Some Cerification Authority CA",
@@ -81,7 +81,7 @@ internal static class CertificateHandlers
             .ToList()
         };
         var crlSeq = new CertificateRevocationListSequence(crl);
-        var data = crlSeq.SignAndSerialize(issuer.GetRSAPrivateKey());
+        var data = crlSeq.SignAndSerialize(issuer.GetRSAPrivateKey()!);
         return TypedResults.File(data, contentType:"application/x-pkcs7-crl", fileDownloadName: "revoked.crl", lastModified: (DateTimeOffset)crl.EffectiveDate);
     }
 }

--- a/src/Indice.Cryptography.AspNetCore/Features/CertificatesBackgroudService.cs
+++ b/src/Indice.Cryptography.AspNetCore/Features/CertificatesBackgroudService.cs
@@ -36,9 +36,9 @@ internal class CertificatesBackgroudService : BackgroundService
         var issuingCert = manager.CreateRootCACertificate(options.IssuerDomain);
         var certBase64 = issuingCert.ExportToPEM();
         var pfxBytes = issuingCert.Export(X509ContentType.Pfx, options.PfxPassphrase);
-        File.WriteAllBytes(Path.Combine(options.Path, "ca.pfx"), pfxBytes);
-        File.WriteAllText(Path.Combine(options.Path, "ca.cer"), certBase64);
-        var store = scope.ServiceProvider.GetService<ICertificatesStore>();
+        File.WriteAllBytes(Path.Combine(options.Path!, "ca.pfx"), pfxBytes);
+        File.WriteAllText(Path.Combine(options.Path!, "ca.cer"), certBase64);
+        var store = scope.ServiceProvider.GetRequiredService<ICertificatesStore>();
         await store.Add(issuingCert, null!);
     }
 
@@ -46,5 +46,4 @@ internal class CertificatesBackgroudService : BackgroundService
         _logger.LogInformation("Bootstrapping Certificates ended.");
         await base.StopAsync(stoppingToken);
     }
-
 }

--- a/src/Indice.Cryptography.AspNetCore/Features/CertificatesStoreInMemory.cs
+++ b/src/Indice.Cryptography.AspNetCore/Features/CertificatesStoreInMemory.cs
@@ -14,7 +14,7 @@ internal class CertificatesStoreInMemory : ICertificatesStore
         throw new NotImplementedException();
     }
 
-    public Task<List<CertificateDetails>> GetList(DateTimeOffset? notBefore = null, bool? revoked = null, string authorityKeyId = null) {
+    public Task<List<CertificateDetails>> GetList(DateTimeOffset? notBefore = null, bool? revoked = null, string? authorityKeyId = null) {
         throw new NotImplementedException();
     }
 

--- a/src/Indice.Cryptography.AspNetCore/Features/EF/DbCertificatesStore.cs
+++ b/src/Indice.Cryptography.AspNetCore/Features/EF/DbCertificatesStore.cs
@@ -28,13 +28,13 @@ public class DbCertificatesStore : ICertificatesStore
     /// Retrieves a stored certificate by Id.
     /// </summary>
     /// <param name="keyId">The id to search for.</param>
-    public async Task<CertificateDetails?> GetById(string keyId) {
+    public async Task<CertificateDetails> GetById(string keyId) {
         var cert = default(CertificateDetails);
         var dbCert = await DbContext.Certificates.FindAsync(keyId);
         if (dbCert != null && !dbCert.Revoked) {
             cert = MapToDetails(dbCert);
         }
-        return cert;
+        return cert!;
     }
 
     /// <summary>

--- a/src/Indice.Cryptography.AspNetCore/Middleware/HttpContextExtensions.cs
+++ b/src/Indice.Cryptography.AspNetCore/Middleware/HttpContextExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Indice.Cryptography.AspNetCore.Middleware;
 
@@ -14,11 +15,11 @@ public static class HttpContextExtensions
     /// </summary>
     /// <param name="httpContext">Encapsulates all HTTP-specific information about an individual HTTP request.</param>
     public static string GetPathAndQuery(this HttpContext httpContext) {
-        var requestFeature = httpContext.Features.Get<IHttpRequestFeature>();
-        var options = (HttpSignatureOptions)httpContext.RequestServices.GetService(typeof(HttpSignatureOptions));
+        var requestFeature = httpContext.Features.GetRequiredFeature<IHttpRequestFeature>();
+        var options = (HttpSignatureOptions)httpContext.RequestServices.GetRequiredService(typeof(HttpSignatureOptions));
         var forwardedPath = httpContext.Request.Headers[options.ForwardedPathHeaderName];
         if (!string.IsNullOrWhiteSpace(forwardedPath)) {
-            return forwardedPath;
+            return forwardedPath!;
         }
         var uri = new Uri($"http://localhost{httpContext.Request.Path}{requestFeature.QueryString}", UriKind.Absolute);
         return uri.PathAndQuery;

--- a/src/Indice.Cryptography.AspNetCore/Middleware/HttpSignatureConfiguration.cs
+++ b/src/Indice.Cryptography.AspNetCore/Middleware/HttpSignatureConfiguration.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using Indice.Cryptography.AspNetCore.Middleware;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -28,7 +29,7 @@ public static class HttpSignatureConfiguration
             services.AddSingleton(options);
             builder.Options = options;
         }
-        builder.Services.AddSingleton<IHttpClientValidationKeysStore, DefaultHttpClientValidationKeysStore>();
+        builder.Services.TryAddSingleton<IHttpClientValidationKeysStore, DefaultHttpClientValidationKeysStore>();
         return builder;
     }
 

--- a/src/Indice.Cryptography.AspNetCore/Middleware/HttpSignatureExtensions.cs
+++ b/src/Indice.Cryptography.AspNetCore/Middleware/HttpSignatureExtensions.cs
@@ -22,19 +22,19 @@ public static class HttpSignatureExtensions
     /// <param name="httpRequest"></param>
     /// <returns></returns>
     public static bool Validate(this HttpSignature signature, SecurityKey key, HttpRequest httpRequest) {
-        var headers = httpRequest.Headers.ToDictionary(x => x.Key, x => (string)x.Value, StringComparer.OrdinalIgnoreCase);
-        var options = (HttpSignatureOptions)httpRequest.HttpContext.RequestServices.GetService(typeof(HttpSignatureOptions));
+        var headers = httpRequest.Headers.ToDictionary(x => x.Key, x => (string)x.Value!, StringComparer.OrdinalIgnoreCase);
+        var options = (HttpSignatureOptions)httpRequest.HttpContext.RequestServices.GetService(typeof(HttpSignatureOptions))!;
         var forwardedPath = httpRequest.Headers[options.ForwardedPathHeaderName];
-        string rawTarget = null;
+        string rawTarget = null!;
         if (!string.IsNullOrWhiteSpace(forwardedPath)) {
-            rawTarget = forwardedPath;
+            rawTarget = forwardedPath!;
         } else {
             var requestFeature = httpRequest.HttpContext.Features.Get<IHttpRequestFeature>();
-            rawTarget = $"{requestFeature.Path}{requestFeature.QueryString}";
+            rawTarget = $"{requestFeature!.Path}{requestFeature.QueryString}";
         }
         headers.Add(HttpRequestTarget.HeaderName, new HttpRequestTarget(httpRequest.Method, rawTarget).ToString());
-        headers.Add(HeaderFieldNames.Created, httpRequest.Headers[options.RequestCreatedHeaderName]);
-        return signature.Validate(key, headers);
+        headers.Add(HeaderFieldNames.Created, httpRequest.Headers[options.RequestCreatedHeaderName]!);
+        return signature.Validate(key, headers!);
     }
 
     /// <summary>
@@ -43,5 +43,6 @@ public static class HttpSignatureExtensions
     /// <param name="signature">The signature to validate.</param>
     /// <param name="key">The public key.</param>
     /// <param name="headers">The headers.</param>
-    public static bool Validate(this HttpSignature signature, SecurityKey key, IDictionary<string, StringValues> headers) => signature.Validate(key, headers.ToDictionary(x => x.Key, x => (string)x.Value, StringComparer.OrdinalIgnoreCase));
+    public static bool Validate(this HttpSignature signature, SecurityKey key, IDictionary<string, StringValues> headers) =>
+        signature.Validate(key, headers.ToDictionary(x => x.Key, x => (string)x.Value!, StringComparer.OrdinalIgnoreCase)!);
 }

--- a/src/Indice.Cryptography.AspNetCore/Middleware/HttpSignatureOptions.cs
+++ b/src/Indice.Cryptography.AspNetCore/Middleware/HttpSignatureOptions.cs
@@ -72,7 +72,7 @@ public class HttpSignatureOptions
     /// <param name="pathString">The path to exclude.</param>
     /// <param name="httpMethods">The HTTP methods to exclude for the given path.</param>
     public HttpSignatureOptions IgnorePath(PathString pathString, params string[] httpMethods) {
-        if (pathString == null) {
+        if (!pathString.HasValue) {
             throw new ArgumentNullException(nameof(pathString), "Cannot ignore a null path.");
         }
         var path = pathString.Value.EnsureLeadingSlash().ToTemplatedDynamicPath();
@@ -83,7 +83,7 @@ public class HttpSignatureOptions
         }
         // Validate HTTP method.
         // There are more of course, but this seems enough for our needs.
-        foreach (var method in httpMethods) {
+        foreach (var method in httpMethods!) {
             var isValidHttpMethod = HttpMethods.IsGet(method) || HttpMethods.IsPost(method) || HttpMethods.IsPut(method) || HttpMethods.IsDelete(method) || HttpMethods.IsPatch(method);
             if (!isValidHttpMethod) {
                 throw new ArgumentException($"HTTP method {method} is not valid.");
@@ -105,7 +105,7 @@ public class HttpSignatureOptions
     /// <param name="httpMethod">The HTTP method of the specified path.</param>
     /// <param name="headerNames">The headers to be included in the signature for this path.</param>
     public bool TryMatch(PathString path, string httpMethod, out List<string> headerNames) {
-        headerNames = null;
+        headerNames = null!;
         if (Mappings.ContainsKey(path)) {
             headerNames = Mappings[path];
             return !StringExtensions.IsIgnoredPath(IgnoredPaths, path, httpMethod);

--- a/src/Indice.Cryptography/Tokens/HttpMessageSigning/HttpDigest.cs
+++ b/src/Indice.Cryptography/Tokens/HttpMessageSigning/HttpDigest.cs
@@ -31,6 +31,12 @@ public class HttpDigest
         [SecurityAlgorithms.RsaSha384Signature] = "sha-384",
         [SecurityAlgorithms.RsaSha512] = "sha-512",
         [SecurityAlgorithms.RsaSha512Signature] = "sha-512",
+        [SecurityAlgorithms.HmacSha256Signature] = "sha-256",
+        [SecurityAlgorithms.HmacSha256] = "sha-256",
+        [SecurityAlgorithms.HmacSha384Signature] = "sha-384",
+        [SecurityAlgorithms.HmacSha384] = "sha-384",
+        [SecurityAlgorithms.HmacSha512Signature] = "sha-512",
+        [SecurityAlgorithms.HmacSha512] = "sha-512"
     };
     /// <summary>
     /// provides a mapping for the 'algorithm' value so that values are within the Http Signature namespace.

--- a/src/Indice.Cryptography/Tokens/HttpMessageSigning/HttpDigest.cs
+++ b/src/Indice.Cryptography/Tokens/HttpMessageSigning/HttpDigest.cs
@@ -9,7 +9,7 @@ namespace Indice.Cryptography.Tokens.HttpMessageSigning;
 /// <summary>
 /// Http Instance digest. Used in a <see cref="HttpSignatureSecurityToken"/> https://tools.ietf.org/html/rfc3230
 /// </summary>
-public class HttpDigest
+public sealed class HttpDigest
 {
     /// <summary>
     /// The header name for this part.
@@ -19,7 +19,7 @@ public class HttpDigest
     /// <summary>
     /// provides a mapping for the 'algorithm' value so that values are within the Http Signature namespace.
     /// </summary>
-    private readonly IDictionary<string, string> OutboundAlgorithmMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+    private static readonly IDictionary<string, string> OutboundAlgorithmMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
         [HashAlgorithmName.MD5.Name!] = "md5",
         [HashAlgorithmName.SHA1.Name!] = "sha-1",
         [HashAlgorithmName.SHA256.Name!] = "sha-256",
@@ -38,10 +38,11 @@ public class HttpDigest
         [SecurityAlgorithms.HmacSha512Signature] = "sha-512",
         [SecurityAlgorithms.HmacSha512] = "sha-512"
     };
+
     /// <summary>
     /// provides a mapping for the 'algorithm' value so that values are within the Http Signature namespace.
     /// </summary>
-    private readonly IDictionary<string, HashAlgorithmName> InboundAlgorithmMap = new Dictionary<string, HashAlgorithmName>(StringComparer.OrdinalIgnoreCase) {
+    private static readonly IDictionary<string, HashAlgorithmName> InboundAlgorithmMap = new Dictionary<string, HashAlgorithmName>(StringComparer.OrdinalIgnoreCase) {
         ["md5"] = HashAlgorithmName.MD5,
         ["sha-1"] = HashAlgorithmName.SHA1,
         ["sha-256"] = HashAlgorithmName.SHA256,

--- a/src/Indice.Cryptography/Tokens/HttpMessageSigning/HttpSignature.cs
+++ b/src/Indice.Cryptography/Tokens/HttpMessageSigning/HttpSignature.cs
@@ -14,7 +14,7 @@ namespace Indice.Cryptography.Tokens.HttpMessageSigning;
 /// The Signature HTTP Header, which is typically used by automated software agents.
 /// As described in https://tools.ietf.org/html/draft-cavage-http-signatures-10
 /// </summary>
-public class HttpSignature : Dictionary<string, object?>
+public sealed class HttpSignature : Dictionary<string, object?>
 {
     /// <summary>
     /// The header name for this part.
@@ -24,7 +24,7 @@ public class HttpSignature : Dictionary<string, object?>
     /// <summary>
     /// Provides a mapping for the 'algorithm' value so that values are within the HTTP Signature namespace.
     /// </summary>
-    private readonly IDictionary<string, string> OutboundAlgorithmMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+    private static readonly IDictionary<string, string> OutboundAlgorithmMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
         [SecurityAlgorithms.RsaSha256Signature] = "rsa-sha256",
         [SecurityAlgorithms.RsaSha512Signature] = "rsa-sha512",
         [SecurityAlgorithms.RsaSha256] = "rsa-sha256",
@@ -41,13 +41,22 @@ public class HttpSignature : Dictionary<string, object?>
     /// <summary>
     /// Provides a mapping for the 'algorithm' value so that values are within the HTTP Signature namespace.
     /// </summary>
-    private readonly IDictionary<string, string> InboundAlgorithmMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+    private static readonly IDictionary<string, string> InboundAlgorithmMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
         ["rsa-sha256"] = SecurityAlgorithms.RsaSha256Signature,
         ["rsa-sha384"] = SecurityAlgorithms.RsaSha384Signature,
         ["rsa-sha512"] = SecurityAlgorithms.RsaSha512Signature,
         ["hmac-sha256"] = SecurityAlgorithms.HmacSha256Signature,
         ["hmac-sha384"] = SecurityAlgorithms.HmacSha384Signature,
         ["hmac-sha512"] = SecurityAlgorithms.HmacSha512Signature
+    };
+
+    private static readonly IDictionary<string, HashAlgorithmName> HashAlgorithmMap = new Dictionary<string, HashAlgorithmName>(StringComparer.OrdinalIgnoreCase) {
+        ["rsa-sha256"] = HashAlgorithmName.SHA256,
+        ["rsa-sha384"] = HashAlgorithmName.SHA384,
+        ["rsa-sha512"] = HashAlgorithmName.SHA512,
+        ["hmac-sha256"] = HashAlgorithmName.SHA256,
+        ["hmac-sha384"] = HashAlgorithmName.SHA384,
+        ["hmac-sha512"] = HashAlgorithmName.SHA512
     };
 
     /// <summary>
@@ -76,7 +85,7 @@ public class HttpSignature : Dictionary<string, object?>
             }
             headerKeyValuesToSign ??= new Dictionary<string, string?>();
             var message = GenerateMessage(headerKeyValuesToSign);
-            var hashingAlgorithm = signingCredentials.Algorithm == OutboundAlgorithmMap[SecurityAlgorithms.RsaSha512Signature] ? HashAlgorithmName.SHA512 : HashAlgorithmName.SHA256;
+            var hashingAlgorithm = HashAlgorithmMap[Algorithm];
             if (signingCredentials is X509SigningCredentials x509SigningCredentials) {
                 using (var key = x509SigningCredentials.Certificate.GetRSAPrivateKey()!) {
                     this[HttpSignatureParameterNames.Signature] = Convert.ToBase64String(key.SignData(Encoding.UTF8.GetBytes(message), hashingAlgorithm, RSASignaturePadding.Pkcs1));
@@ -85,8 +94,8 @@ public class HttpSignature : Dictionary<string, object?>
                 this[HttpSignatureParameterNames.Signature] = Convert.ToBase64String(HashAndSignBytes(Encoding.UTF8.GetBytes(message), rsaKey.Parameters, hashingAlgorithm)!);
             } else if (signingCredentials.Key is X509SecurityKey x509Key) {
                 this[HttpSignatureParameterNames.Signature] = Convert.ToBase64String(HashAndSignBytes(Encoding.UTF8.GetBytes(message), (RSACng)x509Key.PrivateKey, hashingAlgorithm)!);
-            } else if (signingCredentials.Key is JsonWebKey securityKey && Algorithm.Contains("hmac-sha")) {
-                this[HttpSignatureParameterNames.Signature] = Convert.ToBase64String(HashAndSignBytes(Encoding.UTF8.GetBytes(message), securityKey, Algorithm)!);
+            } else if (signingCredentials.Key is JsonWebKey securityKey) {
+                this[HttpSignatureParameterNames.Signature] = Convert.ToBase64String(HashAndSignBytes(Encoding.UTF8.GetBytes(message), securityKey, Algorithm, hashingAlgorithm)!);
             }
             Headers = new HashSet<string>(headerKeyValuesToSign.Where(x => x.Value != null).Select(x => x.Key.ToLowerInvariant()));
             if (headerKeyValuesToSign.TryGetValue(HeaderFieldNames.Created, out var value)) {
@@ -113,18 +122,25 @@ public class HttpSignature : Dictionary<string, object?>
         }
     }
 
-    private static byte[]? HashAndSignBytes(byte[] DataToSign, JsonWebKey jwk, string hmacAlgorithm) {        
+    private static byte[]? HashAndSignBytes(byte[] DataToSign, JsonWebKey jwk, string signingAlgorithm, HashAlgorithmName keyAlgorithm) {
         if (string.IsNullOrEmpty(jwk.K)) {
             throw new ArgumentException("JWK does not contain the 'k' parameter");
         }
 
         try {
-            var key = Base64UrlEncoder.DecodeBytes(jwk.K);
-            using HMAC hmac = hmacAlgorithm switch {
+            var secret = Base64UrlEncoder.DecodeBytes(jwk.K);
+            var key = keyAlgorithm.Name switch {
+                nameof(HashAlgorithmName.SHA256) => SHA256.HashData(secret),
+                nameof(HashAlgorithmName.SHA384) => SHA384.HashData(secret),
+                nameof(HashAlgorithmName.SHA512) => SHA512.HashData(secret),
+                _ => throw new NotSupportedException($"Unsupported algorithm: {signingAlgorithm}")
+            };
+
+            using HMAC hmac = signingAlgorithm switch {
                 "hmac-sha256" => new HMACSHA256(key),
                 "hmac-sha384" => new HMACSHA384(key),
                 "hmac-sha512" => new HMACSHA512(key),
-                _ => throw new NotSupportedException($"Unsupported algorithm: {hmacAlgorithm}")
+                _ => throw new NotSupportedException($"Unsupported algorithm: {signingAlgorithm}")
             };
             return hmac.ComputeHash(DataToSign);
         } catch (CryptographicException e) {
@@ -384,6 +400,15 @@ public class HttpSignature : Dictionary<string, object?>
     public bool Validate(SecurityKey key, IDictionary<string, string?> headers) {
         if (!key.IsSupportedAlgorithm(InboundAlgorithmMap[Algorithm!])) {
             return false;
+        }
+
+        if (key is JsonWebKey jwk) {
+            jwk.K = Algorithm switch {
+                "hmac-sha256" => Base64UrlEncoder.Encode(SHA256.HashData(Base64UrlEncoder.DecodeBytes(jwk.K))),
+                "hmac-sha384" => Base64UrlEncoder.Encode(SHA384.HashData(Base64UrlEncoder.DecodeBytes(jwk.K))),
+                "hmac-sha512" => Base64UrlEncoder.Encode(SHA512.HashData(Base64UrlEncoder.DecodeBytes(jwk.K))),
+                _ => throw new NotSupportedException($"Unsupported algorithm: {Algorithm}")
+            };
         }
 
         var cryptoProviderFactory = key.CryptoProviderFactory;

--- a/src/Indice.Cryptography/X509Certificates/Psd2Attributes.cs
+++ b/src/Indice.Cryptography/X509Certificates/Psd2Attributes.cs
@@ -46,7 +46,7 @@ public class Psd2Attributes
             _roles[1] ? "PSP_PI" : null,
             _roles[2] ? "PSP_AI" : null,
             _roles[3] ? "PSP_IC" : null,
-        }.Where(x => x != null).ToArray();
+        }.Where(x => x != null).ToArray()!;
         set {
             _roles = new bool[4];
             if (value == null)
@@ -65,7 +65,7 @@ public class Psd2Attributes
     /// <summary>
     /// NCAName - competent authority name
     /// </summary>
-    public string AuthorityName { get; set; }
+    public string? AuthorityName { get; set; }
 
     /// <summary>
     /// NCAId - PSD2 Authorization Number or other recognized identifier 

--- a/src/Indice.Cryptography/X509Certificates/QualifiedCertificateStatementsExtension.cs
+++ b/src/Indice.Cryptography/X509Certificates/QualifiedCertificateStatementsExtension.cs
@@ -215,15 +215,15 @@ public class Psd2QcStatement : DerAsnSequence
         var roleSequence = typeSequence?.Value.Where(x => x is DerAsnSequence).FirstOrDefault() as DerAsnSequence;
         var ncaName = typeSequence?.Value[1] as DerAsnUtf8String;
         var ncaId = typeSequence?.Value[2] as DerAsnUtf8String;
-        attributes.AuthorityName = ncaName.Value;
-        attributes.AuthorizationId = NCAId.Parse(ncaId.Value, false);
-        foreach (var item in roleSequence.Value) {
+        attributes.AuthorityName = ncaName?.Value;
+        attributes.AuthorizationId = NCAId.Parse(ncaId!.Value, false);
+        foreach (var item in roleSequence!.Value) {
             if (!(item is DerAsnSequence)) {
                 continue;
             }
             var role = item as DerAsnSequence;
-            var roleOid = role.Value[0] as DerAsnObjectIdentifier;
-            var roleOidString = string.Join(".", roleOid.Value);
+            var roleOid = role!.Value[0] as DerAsnObjectIdentifier;
+            var roleOidString = string.Join(".", roleOid!.Value);
             switch (roleOidString) {
                 case Oid_PSD2_Roles_PSP_AS: attributes.HasAccountServicing = true; break;
                 case Oid_PSD2_Roles_PSP_PI: attributes.HasPaymentInitiation = true; break;

--- a/test/Indice.Cryptography.Tests/CertificateTests.cs
+++ b/test/Indice.Cryptography.Tests/CertificateTests.cs
@@ -1,6 +1,4 @@
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using Indice.Cryptography.X509Certificates;
 using Newtonsoft.Json;
 using Xunit;
@@ -87,7 +85,7 @@ public class CertificateTests
         var crlSeq = new CertificateRevocationListSequence(crl);
         var manager = new CertificateManager();
         var caCert = manager.CreateRootCACertificate("identityserver.gr");
-        var data = crlSeq.SignAndSerialize(caCert.PrivateKey as RSA);
+        var data = crlSeq.SignAndSerialize(caCert.GetRSAPrivateKey());
         File.WriteAllBytes(Path.Combine(Directory.GetCurrentDirectory(), "my.crl"), data);
         Assert.True(true);
     }
@@ -106,7 +104,7 @@ public class CertificateTests
     [Fact]
     public void ImportBase64Certificate() {
         var qwacBase64 = "MIIGxjCCBa6gAwIBAgIURRag25iaaAe9V0468tVevkkwzH8wDQYJKoZIhvcNAQELBQAwgYoxCzAJBgNVBAYTAkdSMQ8wDQYDVQQIEwZBdHRpa2kxDzANBgNVBAcTBkF0aGVuczEVMBMGA1UEChMMQXV0aG9yaXR5IENBMQswCQYDVQQLEwJJVDEaMBgGA1UEAxMRaWRlbnRpdHlzZXJ2ZXIuZ3IxGTAXBgkqhkiG9w0BCQEWCmNhQHRlc3QuZ3IwHhcNMTkwNDE2MTIwNDM4WhcNMjAwNDE2MTIwNDM4WjCBhDEWMBQGA1UEAxMNd3d3LmluZGljZS5ncjESMBAGA1UEChMJSU5ESUNFIE9FMQwwCgYDVQQLEwNXRUIxCzAJBgNVBAYTAkdSMQ8wDQYDVQQIEwZBdHRpa2kxDzANBgNVBAcTBkF0aGVuczEZMBcGA1UEYRMQR1ItQk9HLTgwMDAwMDAwNTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMwuBHjjyNFE9Ibk1gTd50fd5XGafxsQyUnLqf3xnHjj5KLFAF2cHviSC6MSMpPyQStV/m2u50bXoud+EQfGtDkXwerEZHhcSkuaM40arof3rZUwaQSlCb4PvazkNLlrj1miiDLPv8LcqYMFzGuj3Gt2JFYXt3TBJSUZ/G0UThGHi7UCYpAAF8rSaSTUjjUctYzC/pjidUOxSuEZLjzMvF09Mdc/tKL4WZXyPl9OkpzmORzvE3LSeHJ2t2QljElCz8VWgMqjtYamrL+/AWOPhropBYuwKPO34SUaqmLklW3cEm46WM6UfS28jiGoGIKq/vr0Di4wwUN8bcU+srglwV0CAwEAAaOCAyYwggMiMIGIBggrBgEFBQcBAwR8MHoGBgQAgZgnAjBwMEwwEQYHBACBmCcBAQwGUFNQX0FTMBEGBwQAgZgnAQIMBlBTUF9QSTARBgcEAIGYJwEDDAZQU1BfQUkwEQYHBACBmCcBBAwGUFNQX0lDDA5CYW5rIG9mIEdyZWVjZQwQR1ItQk9HLTgwMDAwMDAwNTCCAScGA1UdHwSCAR4wggEaMIIBFqCCARKgggEOhoHDbGRhcDovLy9DTj1NQUNISU5FTkFNRS1EQzAxLUNBLENOPW1hY2hpbmVuYW1lLWRjMDEsQ049Q0RQLENOPVB1YmxpYyUyMEtleSUyMFNlcnZpY2VzLENOPVNlcnZpY2VzLENOPUNvbmZpZ3VyYXRpb24sREM9ZXhhbXBsZSxEQz1vcmc/Y2VydGlmaWNhdGVSZXZvY2F0aW9uTGlzdD9iYXNlP29iamVjdENsYXNzPWNSTERpc3RyaWJ1dGlvblBvaW50hkZodHRwOi8vbWFjaGluZW5hbWUtZGMwMS5leGFtcGxlLm9yZy9DZXJ0RW5yb2xsL01BQ0hJTkVOQU1FLURDMDEtQ0EuY3JsMIIBKAYIKwYBBQUHAQEEggEaMIIBFjAxBggrBgEFBQcwAoYlaHR0cDovL2lkZW50aXR5c2VydmVyLmdyL2NlcnRzL2NhLmNlcjCBrwYIKwYBBQUHMAKGgaJsZGFwOi8vL0NOPURDMVcxMi1EQzAxLUNBLENOPUFJQSxDTj1QdWJsaWMlMjBLZXklMjBTZXJ2aWNlcyxDTj1TZXJ2aWNlcyxDTj1Db25maWd1cmF0aW9uLERDPWNoYW5pYWJhbmssREM9Z3I/Y0FDZXJ0aWZpY2F0ZT9iYXNlP29iamVjdENsYXNzPWNlcnRpZmljYXRpb25BdXRob3JpdHkwLwYIKwYBBQUHMAGGI2h0dHA6Ly9pZGVudGl0eXNlcnZlci5nci9jZXJ0cy9vY3NwMB0GA1UdDgQWBBQC0ySlkZKi5sbu0p56xp+wUHPHRTAfBgNVHSMEGDAWgBSDiFLS80dobhUspqNMrK4XUJ28NTANBgkqhkiG9w0BAQsFAAOCAQEAt0bV9U/yCD1EgrMKhj6OzN1I0Hw0nm+H8CANxptDIeIp41dDPNzlVyotKcu3iGG0kd3TGN4pZO2ZVL5NDtiTjBXDP/qYvb3RrAq2Jns3YbK3LyKw+dDl4Dk9uIe6ehB+dsIwacuzTltlkkh7BcBlmWzsJSxygm8FE8cLUAFqmdzSqS33PiYtX4/6L9tslsEl5xm9UjvgLAaxBJwAATeZQbv8w6SHcmaIHjYyDXlECuX3bzORGom3zugis7EFW0G11/eK7gsCT5X4bS/ImU1BYWP6ayNMyaJwxFKnwMy7170NLvqW51HEATTYHKxrrHpRG3yUR8wHC6vKKf85s82UhQ==";
-        var qwacCert = new X509Certificate2(Encoding.UTF8.GetBytes(qwacBase64), "", X509KeyStorageFlags.Exportable);
+        var qwacCert = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(qwacBase64));
         var statements = default(QualifiedCertificateStatements);
         var policyInfos = default(PolicyInformation[]);
         var accessDescriptions = default(AccessDescription[]);

--- a/test/Indice.Cryptography.Tests/HttpTokenIntegrationTests.cs
+++ b/test/Indice.Cryptography.Tests/HttpTokenIntegrationTests.cs
@@ -183,7 +183,7 @@ public class HttpTokenIntegrationTests
         var server = _host.GetTestServer();
         var messageHandler = new HttpSignatureDelegatingHandler(
             credential: GetSigningCredentials(),
-            headerNames: new[] { "(request-target)", "(created)", "digest", "x-request-id" },
+            headerNames: ["(request-target)", "(created)", "digest", "x-request-id"],
             innerHandler: server.CreateHandler()
         );
         messageHandler.IgnoreResponseValidation = true;
@@ -199,7 +199,7 @@ public class HttpTokenIntegrationTests
 
     private static SigningCredentials GetSigningCredentials() {
         var privateKey = TEST_RSA_PrivateKey_256.ReadAsRSAKey();
-        var cert = new X509Certificate2(Convert.FromBase64String(TEST_X509_PublicKey_2048));
+        var cert = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(TEST_X509_PublicKey_2048));
         var rsa = RSA.Create(privateKey);
         var signingCredentials = new SigningCredentials(new X509SecurityKey(cert.CopyWithPrivateKey(rsa)), SecurityAlgorithms.RsaSha256Signature);
         return signingCredentials;

--- a/test/Indice.Cryptography.Tests/HttpTokenValidationTests.cs
+++ b/test/Indice.Cryptography.Tests/HttpTokenValidationTests.cs
@@ -12,7 +12,7 @@ public class HttpTokenValidationTests
     private const string ValidIssuer = "www.indice.gr";
     private const string ValidSubject = "GR-BOG-800000005";
     private const string TEST_X509_PublicKey_2048 = "MIIF2DCCBMCgAwIBAgIUYf3I4l4wG2d5DrjW/CS0rgmdZbkwDQYJKoZIhvcNAQELBQAwgZExCzAJBgNVBAYTAkdSMQ8wDQYDVQQIEwZBdHRpa2kxDzANBgNVBAcTBkF0aGVuczEVMBMGA1UEChMMQXV0aG9yaXR5IENBMQswCQYDVQQLEwJJVDEhMB8GA1UEAxMYQXV0aG9yaXR5IENBIERvbWFpbiBOYW1lMRkwFwYJKoZIhvcNAQkBFgpjYUB0ZXN0LmdyMB4XDTE5MDQxNjEwMzcwM1oXDTIwMDQxNjEwMzcwM1owgYQxFjAUBgNVBAMTDXd3dy5pbmRpY2UuZ3IxEjAQBgNVBAoTCUlORElDRSBPRTEMMAoGA1UECxMDV0VCMQswCQYDVQQGEwJHUjEPMA0GA1UECBMGQXR0aWtpMQ8wDQYDVQQHEwZBdGhlbnMxGTAXBgNVBGETEEdSLUJPRy04MDAwMDAwMDUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrPTBQQo93GVgpgFCnRPIieVQ+5ZUfonUyQs6fbQj+AXK7fzsIOI/fBOcrgrPfzYfu9/Me0/KjlacYo3ZFFkXQddVIQhoJ9xgo6wpjOHXp3THvC4lFI9RX0Cp2U0ILnBZgX40zgoUWU7KbrE5htxAj8pY/2fZOg0L+8MlpdpDS2nMA/uYS5QtLl3k4/b9SGSK4k97UjZ7qRdJSSLoQYIBz61yR1pkwnVy15uxFLsVpYN+kJ5f1wgtC2Yu0sJC5G0UEH9l+Mlaa3tDOmNTc9M1deXgzAj7PewkYTaex85FP1t3YsK6nvIUAYgNepw0oTdZ7o92wKM4swe1ZLAY63pclAgMBAAGjggIxMIICLTCBiAYIKwYBBQUHAQMEfDB6BgYEAIGYJwIwcDBMMBEGBwQAgZgnAQEMBlBTUF9BUzARBgcEAIGYJwECDAZQU1BfUEkwEQYHBACBmCcBAwwGUFNQX0FJMBEGBwQAgZgnAQQMBlBTUF9JQwwOQmFuayBvZiBHcmVlY2UMEEdSLUJPRy04MDAwMDAwMDUwggEnBgNVHR8EggEeMIIBGjCCARagggESoIIBDoaBw2xkYXA6Ly8vQ049TUFDSElORU5BTUUtREMwMS1DQSxDTj1tYWNoaW5lbmFtZS1kYzAxLENOPUNEUCxDTj1QdWJsaWMlMjBLZXklMjBTZXJ2aWNlcyxDTj1TZXJ2aWNlcyxDTj1Db25maWd1cmF0aW9uLERDPWV4YW1wbGUsREM9b3JnP2NlcnRpZmljYXRlUmV2b2NhdGlvbkxpc3Q/YmFzZT9vYmplY3RDbGFzcz1jUkxEaXN0cmlidXRpb25Qb2ludIZGaHR0cDovL21hY2hpbmVuYW1lLWRjMDEuZXhhbXBsZS5vcmcvQ2VydEVucm9sbC9NQUNISU5FTkFNRS1EQzAxLUNBLmNybDA1BggrBgEFBQcBAQQpMCcwJQYIKwYBBQUHMAKGGWh0dHA6Ly9leGFtcGxlLmNvbS9jYS5jZXIwHQYDVR0OBBYEFEAhMKpUMoCh2otd4Tavj6aX9I62MB8GA1UdIwQYMBaAFPZgB5eqiOUoTeolfLTt++AKR2jEMA0GCSqGSIb3DQEBCwUAA4IBAQAYUxQYjhWLZWtu9stbMaYP/cCTO5wZIA0fSv2oHsbC7cU6Wqtl9R7mqXsTKf9d+KQeV26KnvyKJLDFwQ7brBctl+vEtqVsQVIrRci9xEoURLE3rrskTSVmM9LqclvIQs+Bcdngqa2vGyPRqCOGdXE/X3UQGwR5GXdKa3LQVNtMyvBmVvp0uxIxDdDroW41buvmOVIawiDn9sinDvEg6mYJXKWPPEK9TJ7tecdJkXLigL0EaWaa8IIAnuV07ql9DSNJQpP85e/2mN/648ZjcvO9bW+G4WPh4O6DSQiHdb8m4r6a84KUcgmGVCBVVgAv6ff28l+bTAiiAryoJWtAtdyE";
-    private const string TEST_RSA_PrivateKey_256 = 
+    private const string TEST_RSA_PrivateKey_256 =
         @"-----BEGIN RSA PRIVATE KEY-----
             MIIEowIBAAKCAQEAqz0wUEKPdxlYKYBQp0TyInlUPuWVH6J1MkLOn20I/gFyu387
             CDiP3wTnK4Kz382H7vfzHtPyo5WnGKN2RRZF0HXVSEIaCfcYKOsKYzh16d0x7wuJ
@@ -42,9 +42,9 @@ public class HttpTokenValidationTests
             -----END RSA PRIVATE KEY-----";
 
     [Fact]
-    public void HttpTokenValidationTest() {
+    public void HttpTokenValidationTest_RSA() {
         var privateKey = TEST_RSA_PrivateKey_256.ReadAsRSAKey();
-        var cert = new X509Certificate2(Convert.FromBase64String(TEST_X509_PublicKey_2048));
+        var cert = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(TEST_X509_PublicKey_2048));
         var securityKey = new RsaSecurityKey(privateKey) {
             KeyId = cert.GetSubjectKeyIdentifier()
         };
@@ -57,6 +57,43 @@ public class HttpTokenValidationTests
         var digestHeader = token.Digest.ToString();
         var signatureHeader = token.Signature.ToString();
         var validationKey = new X509SecurityKey(cert);
+        var validatedToken = new HttpSignatureSecurityToken(digestHeader, signatureHeader);
+        var disgestIsValid = validatedToken.Digest.Validate(Encoding.UTF8.GetBytes(payload));
+        var signatureIsValid = validatedToken.Signature.Validate(validationKey, digestHeader, requestId, requestDate, requestTarget);
+        Assert.True(disgestIsValid);
+        Assert.True(signatureIsValid);
+    }
+
+    [Fact]
+    public void HttpTokenValidationTest_HMAC() {
+        // System.ArgumentOutOfRangeException: 'IDX10720: Unable to create KeyedHashAlgorithm for algorithm
+        // 'http://www.w3.org/2001/04/xmldsig-more#hmac-sha256', the key size must be greater than: '256' bits,
+        // key has '160' bits. (Parameter 'keyBytes')'
+
+        // for the above reason, we are setting a GUID as key 
+        var privateKey = "379af4ab-d390-410a-8da1-802d85d59eb5";
+
+        /* hack for keys < 256bits
+        var keyBytes = Encoding.UTF8.GetBytes("this is my key id");
+        var hashBytes = System.Security.Cryptography.SHA256.HashData(keyBytes); 
+        */
+
+        var securityKey = JsonWebKeyConverter.ConvertFromSymmetricSecurityKey(
+            new SymmetricSecurityKey(Encoding.UTF8.GetBytes(privateKey)) {
+                KeyId = "my-symmetric-key-id"
+            }
+        );
+
+        var signingCredentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+        var payload = @"{""amount"":123.9,""date"":""2019-06-21T12:05:40.111Z""}";
+        var requestId = "ed67e7c4-9985-45a9-8f1c-7ce7d9c007fe";
+        var requestDate = DateTime.UtcNow;
+        var requestTarget = new HttpRequestTarget("POST", "/payment");
+        var token = new HttpSignatureSecurityToken(signingCredentials, Encoding.UTF8.GetBytes(payload), requestId, requestDate, requestTarget);
+        var digestHeader = token.Digest.ToString();
+        var signatureHeader = token.Signature.ToString();
+
+        var validationKey = securityKey; // this is symmetric
         var validatedToken = new HttpSignatureSecurityToken(digestHeader, signatureHeader);
         var disgestIsValid = validatedToken.Digest.Validate(Encoding.UTF8.GetBytes(payload));
         var signatureIsValid = validatedToken.Signature.Validate(validationKey, digestHeader, requestId, requestDate, requestTarget);

--- a/test/Indice.Cryptography.Tests/HttpTokenValidationTests.cs
+++ b/test/Indice.Cryptography.Tests/HttpTokenValidationTests.cs
@@ -65,21 +65,10 @@ public class HttpTokenValidationTests
     }
 
     [Fact]
-    public void HttpTokenValidationTest_HMAC() {
-        // System.ArgumentOutOfRangeException: 'IDX10720: Unable to create KeyedHashAlgorithm for algorithm
-        // 'http://www.w3.org/2001/04/xmldsig-more#hmac-sha256', the key size must be greater than: '256' bits,
-        // key has '160' bits. (Parameter 'keyBytes')'
-
-        // for the above reason, we are setting a GUID as key 
-        var privateKey = "379af4ab-d390-410a-8da1-802d85d59eb5";
-
-        /* hack for keys < 256bits
-        var keyBytes = Encoding.UTF8.GetBytes("this is my key id");
-        var hashBytes = System.Security.Cryptography.SHA256.HashData(keyBytes); 
-        */
-
+    public void HttpTokenValidationTest_HMAC() {              
+        var secret = "simple-key";
         var securityKey = JsonWebKeyConverter.ConvertFromSymmetricSecurityKey(
-            new SymmetricSecurityKey(Encoding.UTF8.GetBytes(privateKey)) {
+            new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret)) {
                 KeyId = "my-symmetric-key-id"
             }
         );


### PR DESCRIPTION
# Description
- Support hmac algorithms in signing
- escape early in request verification when algorithm is not supported
- bump version 8.0.1
- add new test with hmac signing/verifying

# Possible weak points in HttpSignature class
1.  To decide if it's an HMAC -> `if (signingCredentials.Key is JsonWebKey securityKey && Algorithm.Contains("hmac-sha"))`
2. magic strings to create the hmac corresponding class
```cs
using HMAC hmac = hmacAlgorithm switch {
                "hmac-sha256" => new HMACSHA256(key),
                "hmac-sha384" => new HMACSHA384(key),
                "hmac-sha512" => new HMACSHA512(key),
                _ => throw new NotSupportedException($"Unsupported algorithm: {hmacAlgorithm}")
            };
```