### PR TITLE
Bump version and enhance key validation logic

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup Label="Assembly Common">
       <Copyright>Copyright (c) 2019 Indice</Copyright>
       <TargetFramework>net8.0</TargetFramework>
-      <VersionPrefix>8.1.0</VersionPrefix>
+      <VersionPrefix>8.1.1</VersionPrefix>
       <!--<VersionSuffix>beta-01</VersionSuffix>-->
       <Authors>Constantinos Leftheris, Giannis Tsenes</Authors>
       <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup Label="Assembly Common">
       <Copyright>Copyright (c) 2019 Indice</Copyright>
       <TargetFramework>net8.0</TargetFramework>
-      <VersionPrefix>8.1.1</VersionPrefix>
+      <VersionPrefix>8.2.0</VersionPrefix>
       <!--<VersionSuffix>beta-01</VersionSuffix>-->
       <Authors>Constantinos Leftheris, Giannis Tsenes</Authors>
       <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Indice.Cryptography/Tokens/HttpMessageSigning/HttpSignature.cs
+++ b/src/Indice.Cryptography/Tokens/HttpMessageSigning/HttpSignature.cs
@@ -402,7 +402,7 @@ public sealed class HttpSignature : Dictionary<string, object?>
             return false;
         }
 
-        if (key is JsonWebKey jwk) {
+        if (key is JsonWebKey {Kty: JsonWebAlgorithmsKeyTypes.Octet } jwk) {
             jwk.K = Algorithm switch {
                 "hmac-sha256" => Base64UrlEncoder.Encode(SHA256.HashData(Base64UrlEncoder.DecodeBytes(jwk.K))),
                 "hmac-sha384" => Base64UrlEncoder.Encode(SHA384.HashData(Base64UrlEncoder.DecodeBytes(jwk.K))),

--- a/src/Indice.Cryptography/Tokens/HttpMessageSigning/HttpSignature.cs
+++ b/src/Indice.Cryptography/Tokens/HttpMessageSigning/HttpSignature.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Microsoft.IdentityModel.Tokens;
 
@@ -86,17 +85,7 @@ public sealed class HttpSignature : Dictionary<string, object?>
             headerKeyValuesToSign ??= new Dictionary<string, string?>();
             var message = GenerateMessage(headerKeyValuesToSign);
             var hashingAlgorithm = HashAlgorithmMap[Algorithm];
-            if (signingCredentials is X509SigningCredentials x509SigningCredentials) {
-                using (var key = x509SigningCredentials.Certificate.GetRSAPrivateKey()!) {
-                    this[HttpSignatureParameterNames.Signature] = Convert.ToBase64String(key.SignData(Encoding.UTF8.GetBytes(message), hashingAlgorithm, RSASignaturePadding.Pkcs1));
-                }
-            } else if (signingCredentials.Key is RsaSecurityKey rsaKey) {
-                this[HttpSignatureParameterNames.Signature] = Convert.ToBase64String(HashAndSignBytes(Encoding.UTF8.GetBytes(message), rsaKey.Parameters, hashingAlgorithm)!);
-            } else if (signingCredentials.Key is X509SecurityKey x509Key) {
-                this[HttpSignatureParameterNames.Signature] = Convert.ToBase64String(HashAndSignBytes(Encoding.UTF8.GetBytes(message), (RSACng)x509Key.PrivateKey, hashingAlgorithm)!);
-            } else if (signingCredentials.Key is JsonWebKey securityKey) {
-                this[HttpSignatureParameterNames.Signature] = Convert.ToBase64String(HashAndSignBytes(Encoding.UTF8.GetBytes(message), securityKey, Algorithm, hashingAlgorithm)!);
-            }
+            this[HttpSignatureParameterNames.Signature] = Convert.ToBase64String(HashAndSignBytes(Encoding.UTF8.GetBytes(message), signingCredentials.Key)!);
             Headers = new HashSet<string>(headerKeyValuesToSign.Where(x => x.Value != null).Select(x => x.Key.ToLowerInvariant()));
             if (headerKeyValuesToSign.TryGetValue(HeaderFieldNames.Created, out var value)) {
                 Created = GetDate(value);
@@ -111,58 +100,35 @@ public sealed class HttpSignature : Dictionary<string, object?>
         SigningCredentials = signingCredentials;
     }
 
-    private static byte[]? HashAndSignBytes(byte[] DataToSign, RSACng RSAalg, HashAlgorithmName hashAlgorithm) {
-        // Create a new instance of RSACryptoServiceProvider using the key from RSAParameters.  
+    private byte[]? HashAndSignBytes(byte[] DataToSign, SecurityKey securityKey) {
+        if (!securityKey.IsSupportedAlgorithm(InboundAlgorithmMap[Algorithm!])) {
+            return null;
+        }
+
+        // This section exist to enforce the proper key length of the symmetric key.
+        // If this code block is removed, then the signee must ensure for the proper key length, according to the algorithm.
+        if (securityKey is JsonWebKey { Kty: JsonWebAlgorithmsKeyTypes.Octet } jwk) {
+            var symmetricKey = Base64UrlEncoder.DecodeBytes(jwk.K);
+            securityKey = new JsonWebKey {
+                Kty = JsonWebAlgorithmsKeyTypes.Octet,
+                KeyId = jwk.KeyId,
+                K = Algorithm switch {
+                    "hmac-sha256" => Base64UrlEncoder.Encode(SHA256.HashData(symmetricKey)),
+                    "hmac-sha384" => Base64UrlEncoder.Encode(SHA384.HashData(symmetricKey)),
+                    "hmac-sha512" => Base64UrlEncoder.Encode(SHA512.HashData(symmetricKey)),
+                    _ => throw new NotSupportedException($"Unsupported algorithm: {Algorithm}")
+                }
+            };
+        }
+
+        var cryptoProviderFactory = securityKey.CryptoProviderFactory;
+        var signatureProvider = cryptoProviderFactory.CreateForSigning(securityKey, InboundAlgorithmMap[Algorithm!]);
+
         try {
-            // Hash and sign the data. Pass a new instance of SHA1CryptoServiceProvider to specify the use of SHA1 for hashing.
-            return RSAalg.SignData(DataToSign, hashAlgorithm, RSASignaturePadding.Pkcs1);
+            return signatureProvider.Sign(DataToSign);
         } catch (CryptographicException e) {
             Console.WriteLine(e.Message);
             return null;
-        }
-    }
-
-    private static byte[]? HashAndSignBytes(byte[] DataToSign, JsonWebKey jwk, string signingAlgorithm, HashAlgorithmName keyAlgorithm) {
-        if (string.IsNullOrEmpty(jwk.K)) {
-            throw new ArgumentException("JWK does not contain the 'k' parameter");
-        }
-
-        try {
-            var secret = Base64UrlEncoder.DecodeBytes(jwk.K);
-            var key = keyAlgorithm.Name switch {
-                nameof(HashAlgorithmName.SHA256) => SHA256.HashData(secret),
-                nameof(HashAlgorithmName.SHA384) => SHA384.HashData(secret),
-                nameof(HashAlgorithmName.SHA512) => SHA512.HashData(secret),
-                _ => throw new NotSupportedException($"Unsupported algorithm: {signingAlgorithm}")
-            };
-
-            using HMAC hmac = signingAlgorithm switch {
-                "hmac-sha256" => new HMACSHA256(key),
-                "hmac-sha384" => new HMACSHA384(key),
-                "hmac-sha512" => new HMACSHA512(key),
-                _ => throw new NotSupportedException($"Unsupported algorithm: {signingAlgorithm}")
-            };
-            return hmac.ComputeHash(DataToSign);
-        } catch (CryptographicException e) {
-            Console.WriteLine(e.Message);
-            return null;
-        }
-    }
-
-    private static byte[]? HashAndSignBytes(byte[] DataToSign, RSAParameters Key, HashAlgorithmName hashAlgorithm) {
-        // Create a new instance of RSACryptoServiceProvider using the key from RSAParameters.  
-        using (var RSAalg = new RSACryptoServiceProvider()) {
-            try {
-                RSAalg.ImportParameters(Key);
-                // Hash and sign the data. Pass a new instance of SHA1CryptoServiceProvider to specify the use of SHA1 for hashing.
-                return RSAalg.SignData(DataToSign, hashAlgorithm, RSASignaturePadding.Pkcs1);
-            } catch (CryptographicException e) {
-                Console.WriteLine(e.Message);
-                return null;
-            } finally {
-                // Set the key container to be cleared when RSA is garbage collected.
-                RSAalg.PersistKeyInCsp = false;
-            }
         }
     }
 
@@ -402,12 +368,19 @@ public sealed class HttpSignature : Dictionary<string, object?>
             return false;
         }
 
-        if (key is JsonWebKey {Kty: JsonWebAlgorithmsKeyTypes.Octet } jwk) {
-            jwk.K = Algorithm switch {
-                "hmac-sha256" => Base64UrlEncoder.Encode(SHA256.HashData(Base64UrlEncoder.DecodeBytes(jwk.K))),
-                "hmac-sha384" => Base64UrlEncoder.Encode(SHA384.HashData(Base64UrlEncoder.DecodeBytes(jwk.K))),
-                "hmac-sha512" => Base64UrlEncoder.Encode(SHA512.HashData(Base64UrlEncoder.DecodeBytes(jwk.K))),
-                _ => throw new NotSupportedException($"Unsupported algorithm: {Algorithm}")
+        // This section exist to enforce the proper key length of the symmetric key.
+        // If this code block is removed, then the caller must ensure for the proper key length, according to the algorithm.
+        if (key is JsonWebKey { Kty: JsonWebAlgorithmsKeyTypes.Octet } jwk) {
+            var symmetricKey = Base64UrlEncoder.DecodeBytes(jwk.K);
+            key = new JsonWebKey {
+                Kty = JsonWebAlgorithmsKeyTypes.Octet,
+                KeyId = jwk.KeyId,
+                K = Algorithm switch {
+                    "hmac-sha256" => Base64UrlEncoder.Encode(SHA256.HashData(symmetricKey)),
+                    "hmac-sha384" => Base64UrlEncoder.Encode(SHA384.HashData(symmetricKey)),
+                    "hmac-sha512" => Base64UrlEncoder.Encode(SHA512.HashData(symmetricKey)),
+                    _ => throw new NotSupportedException($"Unsupported algorithm: {Algorithm}")
+                }
             };
         }
 

--- a/test/Indice.Cryptography.Tests/HttpTokenValidationTests.cs
+++ b/test/Indice.Cryptography.Tests/HttpTokenValidationTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Cryptography.X509Certificates;
+﻿using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Indice.Cryptography.Tokens.HttpMessageSigning;
 using Microsoft.IdentityModel.Tokens;
@@ -42,7 +43,7 @@ public class HttpTokenValidationTests
             -----END RSA PRIVATE KEY-----";
 
     [Fact]
-    public void HttpTokenValidationTest_RSA() {
+    public void HttpTokenValidationTest_RSA_X509() {
         var privateKey = TEST_RSA_PrivateKey_256.ReadAsRSAKey();
         var cert = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(TEST_X509_PublicKey_2048));
         var securityKey = new RsaSecurityKey(privateKey) {
@@ -83,6 +84,36 @@ public class HttpTokenValidationTests
         var signatureHeader = token.Signature.ToString();
 
         var validationKey = securityKey; // this is symmetric
+        var validatedToken = new HttpSignatureSecurityToken(digestHeader, signatureHeader);
+        var disgestIsValid = validatedToken.Digest.Validate(Encoding.UTF8.GetBytes(payload));
+        var signatureIsValid = validatedToken.Signature.Validate(validationKey, digestHeader, requestId, requestDate, requestTarget);
+        Assert.True(disgestIsValid);
+        Assert.True(signatureIsValid);
+    }
+
+    [Fact]
+    public void HttpTokenValidationTest_RSA_JWK() {
+        var privateKey = TEST_RSA_PrivateKey_256.ReadAsRSAKey();
+        var cert = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(TEST_X509_PublicKey_2048));
+        var securityKey = new RsaSecurityKey(privateKey) {
+            KeyId = cert.GetSubjectKeyIdentifier()
+        };
+        var signingCredentials = new SigningCredentials(securityKey, SecurityAlgorithms.RsaSha256Signature);
+        var payload = @"{""amount"":123.9,""date"":""2019-06-21T12:05:40.111Z""}";
+        var requestId = "ed67e7c4-9985-45a9-8f1c-7ce7d9c007fe";
+        var requestDate = DateTime.UtcNow;
+        var requestTarget = new HttpRequestTarget("POST", "/payment");
+        var token = new HttpSignatureSecurityToken(signingCredentials, Encoding.UTF8.GetBytes(payload), requestId, requestDate, requestTarget);
+        var digestHeader = token.Digest.ToString();
+        var signatureHeader = token.Signature.ToString();
+
+        // Get the public key from the private key in JWK format (as it would be received from identity server)
+        var rsa = RSA.Create();
+        rsa.ImportFromPem(TEST_RSA_PrivateKey_256.ToCharArray());
+        var validationKey = JsonWebKeyConverter.ConvertFromRSASecurityKey(new RsaSecurityKey(rsa) {
+            KeyId = securityKey.KeyId
+        });
+
         var validatedToken = new HttpSignatureSecurityToken(digestHeader, signatureHeader);
         var disgestIsValid = validatedToken.Digest.Validate(Encoding.UTF8.GetBytes(payload));
         var signatureIsValid = validatedToken.Signature.Validate(validationKey, digestHeader, requestId, requestDate, requestTarget);


### PR DESCRIPTION
Improved the `Validate` method in `HttpSignature` by adding type pattern matching to ensure `JsonWebKey` has a `Kty` of `JsonWebAlgorithmsKeyTypes.Octet`, enhancing validation robustness.