### PR TITLE
Publish nuget

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,24 @@
+name: Publish NuGet
+
+on: 
+   workflow_dispatch:
+
+jobs:
+  publish:
+      runs-on: ubuntu-latest
+
+      steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Restores the dependencies
+        run: dotnet restore
+
+      - name: Run the tests
+        run: dotnet test
+
+      - name: Build the project
+        run: dotnet build
+      
+      - name: Pack project
+        run: dotnet pack

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,7 +1,9 @@
 name: Publish NuGet
 
 on: 
-   workflow_dispatch:
+   push:
+      branches:
+         - publish-nuget
 
 jobs:
   publish:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -26,7 +26,7 @@ jobs:
         run: dotnet build
 
       - name: Build the project Indice.IdentityServer.Psd2.csproj for net8.0;net9.0
-        run: dotnet build src/Indice.IdentityServer.Psd2/Indice.IdentityServer.Psd2.csproj -c Release -f
+        run: dotnet build src/Indice.IdentityServer.Psd2/Indice.IdentityServer.Psd2.csproj -c Release
 
       - name: Run the tests
         run: dotnet test

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-      runs-on: ubuntu-latest
+      runs-on: windows-latest
 
       steps:
       - name: Checkout repository

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Restores the dependencies
         run: dotnet restore
 
-      - name: Run the tests
-        run: dotnet test
-
       - name: Build the project
         run: dotnet build
+
+      - name: Run the tests
+        run: dotnet test
       
       - name: Pack project
         run: dotnet pack

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,6 +1,7 @@
 name: Publish NuGet
 
 on: 
+  #  workflow_dispatch:
    push:
       branches:
          - publish-nuget
@@ -13,6 +14,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Read global json
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: ${{ github.workspace }}/global.json
+
       - name: Restores the dependencies
         run: dotnet restore
 
@@ -24,3 +30,9 @@ jobs:
       
       - name: Pack project
         run: dotnet pack
+
+      # - name: Generate NuGet package
+      #   run: ./pack.ps1
+
+      # - name: Push to NuGet.org
+      #   run: dotnet nuget push "./artifacts/Indice*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -21,9 +21,12 @@ jobs:
 
       - name: Restores the dependencies
         run: dotnet restore
-
-      - name: Build the project
+ 
+      - name: Build the projects
         run: dotnet build
+
+      - name: Build the project Indice.IdentityServer.Psd2.csproj for net8.0;net9.0
+        run: dotnet build src/Indice.IdentityServer.Psd2/Indice.IdentityServer.Psd2.csproj -c Release -f
 
       - name: Run the tests
         run: dotnet test

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -26,7 +26,9 @@ jobs:
         run: dotnet build
 
       - name: Build the project Indice.IdentityServer.Psd2.csproj for net8.0;net9.0
-        run: dotnet build src/Indice.IdentityServer.Psd2/Indice.IdentityServer.Psd2.csproj -c Release
+        run: | 
+              dotnet build src/Indice.IdentityServer.Psd2/Indice.IdentityServer.Psd2.csproj -c Release -f net8.0
+              dotnet build src/Indice.IdentityServer.Psd2/Indice.IdentityServer.Psd2.csproj -c Release -f net9.0
 
       - name: Run the tests
         run: dotnet test

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,8 +1,12 @@
 name: Publish NuGet
 
-on: 
+on:
   workflow_dispatch:
-
+    inputs:
+      branch:
+        description: 'Branch to run the workflow on'
+        required: true
+        default: 'main'
   
 jobs:
   publish:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -26,9 +26,7 @@ jobs:
         run: dotnet build
 
       - name: Build the project Indice.IdentityServer.Psd2.csproj for net8.0;net9.0
-        run: | 
-              dotnet build src/Indice.IdentityServer.Psd2/Indice.IdentityServer.Psd2.csproj -c Release -f net8.0
-              dotnet build src/Indice.IdentityServer.Psd2/Indice.IdentityServer.Psd2.csproj -c Release -f net9.0
+        run: dotnet build
 
       - name: Run the tests
         run: dotnet test

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -29,4 +29,4 @@ jobs:
         run: dotnet pack -c Release --output packages
 
       - name: Push to NuGet.org
-        run: dotnet nuget push "./packages/Indice*.nupkg" --api-key ${{ secrets.NUGET_AUTH_TOKEN }}
+        run: dotnet nuget push "./packages/Indice*.nupkg" --api-key ${{ secrets.NUGET_AUTH_TOKEN }} --skip-duplicate

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -23,19 +23,15 @@ jobs:
         run: dotnet restore
  
       - name: Build the projects
-        run: dotnet build
-
-      - name: Build the project Indice.IdentityServer.Psd2.csproj for net8.0;net9.0
-        run: dotnet build
+        run: dotnet build -c Release
 
       - name: Run the tests
         run: dotnet test
       
       - name: Pack project
-        run: dotnet pack
-
-      # - name: Generate NuGet package
-      #   run: ./pack.ps1
+        run: |
+             dotnet pack -c Release --output packages
+             ls -la packages
 
       # - name: Push to NuGet.org
-      #   run: dotnet nuget push "./artifacts/Indice*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }}
+      #   run: dotnet nuget push "./artifacts/Indice*.nupkg" --api-key ${{ secrets.NUGET_AUTH_TOKEN }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,11 +1,9 @@
 name: Publish NuGet
 
 on: 
-  #  workflow_dispatch:
-   push:
-      branches:
-         - publish-nuget
+  workflow_dispatch:
 
+  
 jobs:
   publish:
       runs-on: windows-latest
@@ -29,9 +27,7 @@ jobs:
         run: dotnet test
       
       - name: Pack project
-        run: |
-             dotnet pack -c Release --output packages
-             ls packages
+        run: dotnet pack -c Release --output packages
 
-      # - name: Push to NuGet.org
-      #   run: dotnet nuget push "./artifacts/Indice*.nupkg" --api-key ${{ secrets.NUGET_AUTH_TOKEN }}
+      - name: Push to NuGet.org
+        run: dotnet nuget push "./packages/Indice*.nupkg" --api-key ${{ secrets.NUGET_AUTH_TOKEN }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -2,12 +2,7 @@ name: Publish NuGet
 
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to run the workflow on'
-        required: true
-        default: 'main'
-  
+
 jobs:
   publish:
       runs-on: windows-latest

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Pack project
         run: |
              dotnet pack -c Release --output packages
-             ls -la packages
+             ls packages
 
       # - name: Push to NuGet.org
       #   run: dotnet nuget push "./artifacts/Indice*.nupkg" --api-key ${{ secrets.NUGET_AUTH_TOKEN }}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup Label="Assembly Common">
       <Copyright>Copyright (c) 2019 Indice</Copyright>
       <!--<TargetFramework>net8.0</TargetFramework> -->
-      <VersionPrefix>8.1.0</VersionPrefix>
+      <VersionPrefix>8.2.0</VersionPrefix>
       <!--<VersionSuffix>beta-01</VersionSuffix>-->
       <Authors>Constantinos Leftheris, Giannis Tsenes</Authors>
       <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup Label="Assembly Common">
       <Copyright>Copyright (c) 2019 Indice</Copyright>
-      <TargetFramework>net8.0</TargetFramework>
+      <!--<TargetFramework>net8.0</TargetFramework> -->
       <VersionPrefix>8.1.0</VersionPrefix>
       <!--<VersionSuffix>beta-01</VersionSuffix>-->
       <Authors>Constantinos Leftheris, Giannis Tsenes</Authors>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup Label="Assembly Common">
       <Copyright>Copyright (c) 2019 Indice</Copyright>
-      <TargetFramework>net8.0</TargetFramework>
+      <!-- <TargetFramework>net8.0</TargetFramework> -->
       <VersionPrefix>8.2.0</VersionPrefix>
       <!--<VersionSuffix>beta-01</VersionSuffix>-->
       <Authors>Constantinos Leftheris, Giannis Tsenes</Authors>

--- a/src/Indice.Cryptography.AspNetCore/Indice.Cryptography.AspNetCore.csproj
+++ b/src/Indice.Cryptography.AspNetCore/Indice.Cryptography.AspNetCore.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Package">
+    <TargetFramework>net8.0</TargetFramework>
     <PackageTags>Psd2;OBA;FAPI;Extensions</PackageTags>
     <PackageReleaseNotes>Expose header name.</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Initial setup for automating the creation and publishing of NuGet packages for the Indice.Cryptography project.

This PR introduces a GitHub Actions workflow that will handle the build and publish process to NuGet.org.

The workflow is still in progress and under review.
